### PR TITLE
HOTFIX cover parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ResearchNow Book Cover s3 Storage
 
-[![GitHub version](https://badge.fury.io/gh/nypl%2Fsfr-covers-to-s3.svg)](https://badge.fury.io/gh/nypl%2Fsfr-covers-to-s3)
-
-[![Build Status](https://travis-ci.com/NYPL/sfr-covers-to-s3.svg?branch=development)](https://travis-ci.com/NYPL/sfr-covers-to-s3)
+[![GitHub version](https://badge.fury.io/gh/nypl%2Fsfr-covers-to-s3.svg)](https://badge.fury.io/gh/nypl%2Fsfr-covers-to-s3) [![Build Status](https://travis-ci.com/NYPL/sfr-covers-to-s3.svg?branch=development)](https://travis-ci.com/NYPL/sfr-covers-to-s3)
 
 ## Summary
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,3 +3,4 @@
 environment_variables:
     LOG_LEVEL: debug
     COVER_BUCKET: test-sfr-covers
+    DB_UPDATE_STREAM: sfr-db-update-development

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -3,4 +3,4 @@
 environment_variables:
     LOG_LEVEL: debug
     COVER_BUCKET: test-sfr-covers
-    DB_UPDATE_STREAM: sfr-db-updates-development
+    DB_UPDATE_STREAM: sfr-db-update-development

--- a/lib/covers.py
+++ b/lib/covers.py
@@ -26,6 +26,8 @@ class CoverParse:
         if not url:
             self.logger.error('URL not provided to cover ingester')
             raise InvalidParameter('URL must be supplied to CoverParse()')
+        if url[:4] != 'http':
+            url = 'http://{}'.format(url)
         parsedURL = urlparse(url)
         if not parsedURL.scheme or not parsedURL.netloc:
             self.logger.error('Invalid URL provided, unable to access cover')

--- a/lib/covers.py
+++ b/lib/covers.py
@@ -29,7 +29,7 @@ class CoverParse:
         if url[:4] != 'http':
             url = 'http://{}'.format(url)
         parsedURL = urlparse(url)
-        if not parsedURL.scheme or not parsedURL.netloc:
+        if not parsedURL.scheme or not parsedURL.netloc or not parsedURL.path:
             self.logger.error('Invalid URL provided, unable to access cover')
             raise InvalidParameter('Unable to validate URL {}'.format(url))
 

--- a/tests/test_covers.py
+++ b/tests/test_covers.py
@@ -36,6 +36,15 @@ class TestCoverParse:
         with pytest.raises(InvalidParameter):
             CoverParse(testRecord)
 
+    def test_CoverParseInit_no_httpURL(self, testRecord):
+        outURL = testRecord['url']
+        testRecord['url'] = testRecord['url'][7:]
+        testParser = CoverParse(testRecord)
+        assert testParser.remoteURL == outURL
+        assert testParser.source == testRecord['source']
+        assert testParser.sourceID == testRecord['identifier']
+        assert testParser.s3CoverURL is None
+
     def test_CoverParseInit_missingURL(self, testRecord):
         testRecord.pop('url')
         with pytest.raises(InvalidParameter):


### PR DESCRIPTION
This method did not properly parse URLs when passed without the `http/https` scheme, failing the validation check in the `covers.py` module. This prevented covers from Project Gutenberg from being stored.

This update allows them to be stored by appending a scheme if none is present and implementing stricter checking of valid URLs by looking for the presence of a `path` in addition to `location`. This is under the assumption that all files will necessarily have a `path`.

In testing this successfully processed covers and provided them to the `db-updater` stream where they were successfully processed 