### PR TITLE
SFR-774 cover resizer

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 coverage
 flake8
+Pillow
 pytest
 pytest-mock

--- a/lib/covers.py
+++ b/lib/covers.py
@@ -77,7 +77,11 @@ class CoverParse:
         s3 = s3Client(coverKey)
         existingFile = s3.checkForFile()
         if existingFile is None:
-            self.s3CoverURL = s3.storeNewFile(imgResp.content)
+            resizer = CoverResizer(imgResp.content)
+            resizer.getNewDimensions()
+            resizer.resizeCover()
+            standardCoverBytes = resizer.getCoverInBytes()
+            self.s3CoverURL = s3.storeNewFile(standardCoverBytes, mimeType)
         else:
             self.s3CoverURL = existingFile
 

--- a/lib/covers.py
+++ b/lib/covers.py
@@ -1,3 +1,4 @@
+from mimetypes import guess_type
 import re
 import requests
 from requests.exceptions import ReadTimeout
@@ -74,6 +75,7 @@ class CoverParse:
             )
 
         coverKey = self.createKey()
+        mimeType = self.getMimeType(coverKey)
         s3 = s3Client(coverKey)
         existingFile = s3.checkForFile()
         if existingFile is None:
@@ -96,6 +98,9 @@ class CoverParse:
             urlMatch = re.search(self.URL_ID_REGEX, self.remoteURL)
             urlID = urlMatch.group(1)
         return '{}/{}_{}'.format(self.source, self.sourceID, urlID.lower())
+
+    def getMimeType(self, key):
+        return guess_type(key)[0]
 
     @classmethod
     def createAuth(cls):

--- a/lib/resizer.py
+++ b/lib/resizer.py
@@ -1,0 +1,38 @@
+from PIL import Image
+from io import BytesIO
+
+
+class CoverResizer:
+    def __init__(self, coverBytes):
+        self.original = self.loadOriginal(coverBytes)
+        self.loadImageData()
+
+    def loadOriginal(self, coverBytes):
+        return Image.open(BytesIO(coverBytes))
+
+    def loadImageData(self):
+        self.oWidth = self.original.width
+        self.oHeight = self.original.height
+        self.format = self.original.format
+
+    def getNewDimensions(self):
+        originalRatio = self.oWidth / self.oHeight
+
+        if 400 * originalRatio > 300:
+            if originalRatio > 1:
+                self.rHeight = int(round(300 / originalRatio))
+            else:
+                self.rHeight = int(round(300 * originalRatio))
+            self.rWidth = 300
+        else:
+            self.rHeight = 400
+            self.rWidth = int(round(400 * originalRatio))
+
+    def resizeCover(self):
+        self.standard = self.original.resize((self.rWidth, self.rHeight))
+
+    def getCoverInBytes(self):
+        outBytes = BytesIO()
+        self.standard.save(outBytes, format=self.format)
+        return outBytes.getvalue()
+

--- a/lib/resizer.py
+++ b/lib/resizer.py
@@ -35,4 +35,3 @@ class CoverResizer:
         outBytes = BytesIO()
         self.standard.save(outBytes, format=self.format)
         return outBytes.getvalue()
-

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -27,12 +27,13 @@ class s3Client:
 
         return None
 
-    def storeNewFile(self, fileContents):
+    def storeNewFile(self, fileContents, mimeType):
         self.s3Client.put_object(
             Bucket=self.bucket,
             Key=self.key,
             ACL='public-read',
-            Body=BytesIO(fileContents).read()
+            Body=BytesIO(fileContents).read(),
+            ContentType=mimeType
         )
         return self.returnS3URL()
 

--- a/tests/test_resizer.py
+++ b/tests/test_resizer.py
@@ -1,0 +1,99 @@
+from PIL import Image
+import pytest
+
+from lib.resizer import CoverResizer
+
+
+class TestCoverResize:
+    @pytest.fixture
+    def mockLoad(self, mocker):
+        return mocker.patch.object(CoverResizer, 'loadOriginal')
+
+    @pytest.fixture
+    def mockData(self, mocker):
+        return mocker.patch.object(CoverResizer, 'loadImageData')
+
+    def test_init_resizer(self, mockLoad, mockData):
+        testResizer = CoverResizer('testImageBytes')
+        assert isinstance(testResizer, CoverResizer)
+        mockLoad.assert_called_once_with('testImageBytes')
+        mockData.assert_called_once()
+
+    def test_loadOriginal(self, mocker, mockData):
+        mockImage = mocker.patch.object(Image, 'open')
+        mockBytes = mocker.patch('lib.resizer.BytesIO', return_value='testB')
+        mockImage.return_value = 'pillow_image'
+        testResizer = CoverResizer('testImageBytes')
+        assert testResizer.original == 'pillow_image'
+        mockBytes.assert_called_once_with('testImageBytes')
+        mockImage.assert_called_once_with('testB')
+        mockData.assert_called_once()
+
+    def test_loadImageData(self, mocker, mockLoad):
+        mockImg = mocker.MagicMock()
+        mockImg.width = 300
+        mockImg.height = 400
+        mockImg.format = 'test'
+        mockLoad.return_value = mockImg
+        testResizer = CoverResizer('testImageBytes')
+        assert testResizer.oWidth == 300
+        assert testResizer.oHeight == 400
+        assert testResizer.format == 'test'
+
+    def test_getNewDimensions_long(self, mockLoad, mockData):
+        testResizer = CoverResizer('testImageBytes')
+        testResizer.oWidth = 450
+        testResizer.oHeight = 900
+
+        testResizer.getNewDimensions()
+
+        assert testResizer.rHeight == 400
+        assert testResizer.rWidth == 200
+
+    def test_getNewDimensions_short(self, mockLoad, mockData):
+        testResizer = CoverResizer('testImageBytes')
+        testResizer.oWidth = 500
+        testResizer.oHeight = 350
+
+        testResizer.getNewDimensions()
+
+        assert testResizer.rHeight == 210
+        assert testResizer.rWidth == 300
+
+    def test_getNewDimensions_square(self, mockLoad, mockData):
+        testResizer = CoverResizer('testImageBytes')
+        testResizer.oWidth = 550
+        testResizer.oHeight = 600
+
+        testResizer.getNewDimensions()
+
+        assert testResizer.rHeight == 275
+        assert testResizer.rWidth == 300
+
+    def test_resizeCover(self, mocker, mockLoad, mockData):
+        testImg = mocker.MagicMock()
+        testImg.resize.return_value = 'resizedImage'
+        mockLoad.return_value = testImg
+        testResizer = CoverResizer('testImageBytes')
+        testResizer.rWidth = 300
+        testResizer.rHeight = 400
+        testResizer.resizeCover()
+        assert testResizer.standard == 'resizedImage'
+        testImg.resize.assert_called_once_with((300, 400))
+
+    def test_getCoverInBytes(self, mocker, mockLoad, mockData):
+        mockIO = mocker.patch('lib.resizer.BytesIO')
+        mockBytes = mocker.MagicMock()
+        mockIO.return_value = mockBytes
+        mockBytes.getvalue.return_value = 'standardBytes'
+        testResizer = CoverResizer('testImageBytes')
+
+        testResizer.standard = mocker.MagicMock()
+        testResizer.format = 'test'
+
+        testOut = testResizer.getCoverInBytes()
+
+        assert testOut == 'standardBytes'
+        testResizer.standard.save.assert_called_once_with(
+            mockBytes, format='test'
+        )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -22,7 +22,7 @@ class TestS3Client:
     def test_s3Client_storeNewFile_success(self, mocker, testClient):
         mocker.patch.object(s3Client, 'returnS3URL', return_value=True)
         mocker.patch('lib.s3.BytesIO')()
-        newURL = testClient.storeNewFile('file_contents')
+        newURL = testClient.storeNewFile('file_contents', 'testMime')
         assert newURL is True
 
     def test_returnS3URL(self, testClient):


### PR DESCRIPTION
This adds a simple resizer class to the function that transforms the covers to files at most 300x400, retaining the original format and making no other transformations.

This uses the `Pillow` module, which has C dependencies that must be explicitly loaded into the lambda environment via a layer.