### PR TITLE
SFR-805 fix bucket key

### DIFF
--- a/lib/covers.py
+++ b/lib/covers.py
@@ -25,6 +25,7 @@ class CoverParse:
         self.logger = LOGGER
         self.source = record.get('source', 'unk')
         self.sourceID = record.get('identifier', None)
+        self.originalURL = record.get('url', None)
         self.remoteURL = record.get('url', None)
         self.s3CoverURL = None
         self.logger.debug('Source: {}|ID: {}|URL: {}'.format(

--- a/lib/covers.py
+++ b/lib/covers.py
@@ -110,7 +110,11 @@ class CoverParse:
         else:
             urlMatch = re.search(self.URL_ID_REGEX, self.remoteURL)
             urlID = urlMatch.group(1)
-        return '{}/{}_{}'.format(self.source, self.sourceID, urlID.lower())
+        return '{}/{}_{}'.format(
+            self.source.lower(),
+            self.sourceID,
+            urlID.lower()
+        )
 
     def getMimeType(self, key):
         return guess_type(key)[0]

--- a/service.py
+++ b/service.py
@@ -69,7 +69,7 @@ def parseRecord(encodedRec, outManager):
 
     outManager.putKinesis(
         {
-            'originalURL': coverParser.remoteURL.lower(),
+            'originalURL': coverParser.originalURL.lower(),
             'storedURL': coverParser.s3CoverURL
         },
         os.environ['DB_UPDATE_STREAM'],


### PR DESCRIPTION
This coerces the name of the source to lower case for use in the s3 Key as the database will force all URIs to be lowercase (as they should be) and this is necessary to ensure compatibility with that.